### PR TITLE
add LLM for program reduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@
 
 - Active Inductive Logic Programming for Code Search, ICSE 2019, [Link](http://web.cs.ucla.edu/~miryung/Publications/icse2019-alice.pdf)
 
+- LPR: Large Language Models-Aided Program Reduction. ISSTA 2024, [Link](https://cs.uwaterloo.ca/~cnsun/public/publication/issta24/issta24.pdf)
 
 ### Fuzzing and Testing
 


### PR DESCRIPTION
Hi, can I add a ISSTA paper for program reduction? It can be categorized into Code Generation or Testing. Thank you!